### PR TITLE
Add support for specifying the semver-range

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - '6'
-  - '4'
+  - '12'
+  - '10'
+  - '8'

--- a/cli.js
+++ b/cli.js
@@ -5,18 +5,18 @@ const latestVersion = require('latest-version');
 
 const cli = meow(`
 	Usage
-		$ latest-version <package-name> [options...]
+	  $ latest-version <package-name>
 
 	Options
-		-v       	Ouput current version number of this package
-		--version	Specify which dist-tag to use to find the latest version
+	  -v         Ouput the version of this package
+	  --version  Specify which dist-tag to use to find the latest version
 
 	Example
 	  $ latest-version ava
-		2.4.0
+	  2.4.0
 
-		$ latest-version ava --version=next
-		2.0.0-rc.1
+	  $ latest-version ava --version=next
+	  2.0.0-rc.1
 `, {
 	autoVersion: false
 });

--- a/cli.js
+++ b/cli.js
@@ -5,16 +5,32 @@ const latestVersion = require('latest-version');
 
 const cli = meow(`
 	Usage
-	  $ latest-version <package-name>
+		$ latest-version <package-name> [options...]
+
+	Options
+		-v       	Ouput current version number of this package
+		--version	Specify which dist-tag to use to find the latest version
 
 	Example
 	  $ latest-version ava
-	  0.18.0
-`);
+		2.4.0
+
+		$ latest-version ava --version=next
+		2.0.0-rc.1
+`, {
+	autoVersion: false
+});
+
+if (cli.flags.v) {
+	cli.showVersion();
+}
 
 if (cli.input.length === 0) {
 	console.error('Please specify a package name');
 	process.exit(1);
 }
 
-latestVersion(cli.input[0]).then(console.log);
+(async () => {
+	const result = await latestVersion(cli.input[0], cli.flags);
+	console.log(result);
+})();

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "latest-version": "cli.js"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "scripts": {
     "test": "xo && ava"
@@ -34,13 +34,13 @@
     "module"
   ],
   "dependencies": {
-    "latest-version": "^3.0.0",
-    "meow": "^3.4.2"
+    "latest-version": "^5.1.0",
+    "meow": "^6.0.0"
   },
   "devDependencies": {
-    "ava": "*",
-    "execa": "^0.6.0",
-    "semver-regex": "^1.0.0",
-    "xo": "*"
+    "ava": "^2.4.0",
+    "execa": "^3.4.0",
+    "semver-regex": "^3.1.0",
+    "xo": "^0.25.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -15,19 +15,19 @@ $ npm install --global latest-version-cli
 ```
 $ latest-version --help
 
-	Usage
-		$ latest-version <package-name> [options...]
+  Usage
+    $ latest-version <package-name>
 
-	Options
-		-v       	Ouput current version number of this module
-		--version	Specify which dist-tag to use to find the latest version
+  Options
+    -v         Ouput the version of this package
+    --version  Specify which dist-tag to use to find the latest version
 
-	Example
-	  $ latest-version ava
-		2.4.0
+  Example
+    $ latest-version ava
+    2.4.0
 
-		$ latest-version ava --version=next
-		2.0.0-rc.1
+    $ latest-version ava --version=next
+    2.0.0-rc.1
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -15,12 +15,19 @@ $ npm install --global latest-version-cli
 ```
 $ latest-version --help
 
-  Usage
-    $ latest-version <package-name>
+	Usage
+		$ latest-version <package-name> [options...]
 
-  Example
-    $ latest-version ava
-    0.18.0
+	Options
+		-v       	Ouput current version number of this module
+		--version	Specify which dist-tag to use to find the latest version
+
+	Example
+	  $ latest-version ava
+		2.4.0
+
+		$ latest-version ava --version=next
+		2.0.0-rc.1
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -2,7 +2,12 @@ import test from 'ava';
 import execa from 'execa';
 import semverRegex from 'semver-regex';
 
-test(async t => {
+test('test without flags', async t => {
 	const {stdout} = await execa('./cli.js', ['ava']);
 	t.regex(stdout, semverRegex());
+});
+
+test('test with flags', async t => {
+	const {stdout} = await execa('./cli.js', ['update-notifier-tester', '--version=0.0.3-rc1']);
+	t.is(stdout, '0.0.3-rc1');
 });

--- a/test.js
+++ b/test.js
@@ -2,12 +2,12 @@ import test from 'ava';
 import execa from 'execa';
 import semverRegex from 'semver-regex';
 
-test('test without flags', async t => {
+test('main', async t => {
 	const {stdout} = await execa('./cli.js', ['ava']);
 	t.regex(stdout, semverRegex());
 });
 
-test('test with flags', async t => {
+test('--version', async t => {
 	const {stdout} = await execa('./cli.js', ['update-notifier-tester', '--version=0.0.3-rc1']);
 	t.is(stdout, '0.0.3-rc1');
 });


### PR DESCRIPTION
### Changes

- Add support for specifying the [dist-tag](https://docs.npmjs.com/adding-dist-tags-to-packages) by passing the flag `--version`.
- Upgrade devDependencies to the latest version.
- Requrie Node.js 8.
- Add `.npmrc` file to disable npm lockfile.

Fixes #2