### PR TITLE
Target Node.js 18, expose options, gracefully handle errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
-          - 14
-          - 12
+          - 21
+          - 20
+          - 18
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/cli.js
+++ b/cli.js
@@ -15,9 +15,9 @@ const cli = meow(`
 
 	Examples
 	  $ latest-version ava
-	  3.13.0
+	  6.1.1
 	  $ latest-version electron --range=beta
-	  11.0.0-beta.11
+	  29.0.0-beta.12
 `, {
 	importMeta: import.meta,
 	flags: {

--- a/cli.js
+++ b/cli.js
@@ -1,13 +1,17 @@
 #!/usr/bin/env node
+import process from 'node:process';
 import meow from 'meow';
-import latestVersion from 'latest-version';
+import latestVersion, {PackageNotFoundError, VersionNotFoundError} from 'latest-version';
+import logSymbols from 'log-symbols';
 
 const cli = meow(`
 	Usage
 	  $ latest-version <package-name>
 
 	Options
-	  --range  Specify which semver range to use to find the latest version
+	  --range          Specify which semver range to use to find the latest version
+	  --registry-url   Custom registry URL
+	  --no-deprecated  Omit deprecated versions
 
 	Examples
 	  $ latest-version ava
@@ -20,6 +24,13 @@ const cli = meow(`
 		range: {
 			type: 'string',
 		},
+		registryUrl: {
+			type: 'string',
+		},
+		deprecated: {
+			type: 'boolean',
+			default: true,
+		},
 	},
 });
 
@@ -28,9 +39,21 @@ if (cli.input.length === 0) {
 	process.exit(1);
 }
 
-(async () => {
-	const {range: version} = cli.flags;
+const options = {
+	version: cli.flags.range,
+	registryUrl: cli.flags.registryUrl,
+	omitDeprecated: !cli.flags.deprecated,
+};
 
-	const result = await latestVersion(cli.input[0], version ? {version} : {});
+try {
+	const result = await latestVersion(cli.input[0], options);
 	console.log(result);
-})();
+} catch (error) {
+	if (error instanceof PackageNotFoundError || error instanceof VersionNotFoundError) {
+		console.error(`${logSymbols.error} ${error.message}.`);
+		process.exitCode = 1;
+	} else {
+		throw error;
+	}
+}
+

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
 	},
 	"type": "module",
 	"bin": {
-		"latest-version": "cli.js"
+		"latest-version": "./cli.js"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -35,13 +35,14 @@
 		"module"
 	],
 	"dependencies": {
-		"latest-version": "^6.0.0",
-		"meow": "^10.1.0"
+		"latest-version": "^9.0.0",
+		"log-symbols": "^6.0.0",
+		"meow": "^13.2.0"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"execa": "^5.1.1",
-		"semver-regex": "^4.0.0",
-		"xo": "^0.42.0"
+		"ava": "^6.1.1",
+		"execa": "^8.0.1",
+		"semver-regex": "^4.0.5",
+		"xo": "^0.57.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,8 @@
 
 ## Install
 
-```
-$ npm install --global latest-version-cli
+```sh
+npm install --global latest-version-cli
 ```
 
 ## Usage
@@ -17,7 +17,9 @@ $ latest-version --help
     $ latest-version <package-name>
 
   Options
-    --range  Specify which semver range to use to find the latest version
+    --range          Specify which semver range to use to find the latest version
+    --registry-url   Custom registry URL
+    --no-deprecated  Omit deprecated versions
 
   Examples
     $ latest-version ava

--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,9 @@ $ latest-version --help
 
   Examples
     $ latest-version ava
-    3.13.0
+    6.1.1
     $ latest-version electron --range=beta
-    11.0.0-beta.11
+    29.0.0-beta.12
 ```
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -1,13 +1,53 @@
 import test from 'ava';
-import execa from 'execa';
+import {execa} from 'execa';
 import semverRegex from 'semver-regex';
 
-test('main', async t => {
-	const {stdout} = await execa('./cli.js', ['ava']);
-	t.regex(stdout, semverRegex());
+const verify = test.macro(async (t, {args, expected, error}) => {
+	const {stdout, stderr} = await execa('./cli.js', args.split(' '), {reject: false, env: {NO_COLOR: '1'}});
+
+	if (error) {
+		t.is(stderr, error);
+	} else if (expected instanceof RegExp) {
+		t.regex(stdout, expected);
+	} else {
+		t.is(stdout, expected);
+	}
 });
 
-test('--range', async t => {
-	const {stdout} = await execa('./cli.js', ['update-notifier-tester', '--range=0.0.3-rc1']);
-	t.is(stdout, '0.0.3-rc1');
+test('main', verify, {
+	args: 'ava',
+	expected: semverRegex(),
+});
+
+test('--range', verify, {
+	args: 'update-notifier-tester --range=0.0.3-rc1',
+	expected: '0.0.3-rc1',
+});
+
+test('--registry-url', verify, {
+	args: 'ava --registry-url=https://registry.yarnpkg.com',
+	expected: semverRegex(),
+});
+
+test('includes deprecated versions by default', verify, {
+	args: 'querystring',
+	expected: '0.2.1',
+});
+
+test('flags: --no-deprecated', verify, {
+	args: 'querystring --range=0.2 --no-deprecated',
+	error: '✖ Version `0.2` for package `querystring` could not be found.',
+});
+
+// TODO: maybe packageJson('querystring', {omitDeprecated: true}) should throw:
+// All versions of the package `querystring` are deprecated.
+
+test('package does not exist', verify, {
+	args: 'nnnope',
+	error: '✖ Package `nnnope` could not be found.',
+});
+
+test('version does not exist', verify, {
+	args: 'ava --range=next',
+	error: '✖ Version `next` for package `ava` could not be found.',
 });


### PR DESCRIPTION
Adds `--registry-url` and `--no-deprecated` and handles `package-json` errors:

```
$ latest-version nnnope
✖ Package `nnnope` could not be found.
```

```
$ latest-version ava --range=next
✖ Version `next` for package `ava` could not be found.
```

---

Blocker: https://github.com/sindresorhus/package-json/pull/82